### PR TITLE
Inline CI workflow actions and adopt Gradle Enhanced Caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,28 @@ jobs:
       contents: read
 
     steps:
-      - uses: huanshankeji/.github/actions/gradle-test-and-check@v0.3.0
+      - uses: actions/checkout@v6
+
+      - name: Set up Temurin JDK 11
+        uses: actions/setup-java@v5
         with:
-          jdk-versions: 11-temurin, 17-temurin
+          java-version: 11
+          distribution: "temurin"
+
+      - name: Set up Temurin JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Test with Gradle Wrapper
+        run: ./gradlew test
+
+      - name: Check with Gradle Wrapper
+        run: ./gradlew check
 
   dependency-submission:
     if: github.ref == 'refs/heads/main'
@@ -25,6 +44,19 @@ jobs:
       contents: write
 
     steps:
-      - uses: huanshankeji/.github/actions/gradle-dependency-submission@v0.3.0
+      - uses: actions/checkout@v6
+
+      - name: Set up Temurin JDK 11
+        uses: actions/setup-java@v5
         with:
-          jdk-versions: 11-temurin, 17-temurin
+          java-version: 11
+          distribution: "temurin"
+
+      - name: Set up Temurin JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: "temurin"
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up JDK 11
         uses: actions/setup-java@v5
@@ -33,4 +33,4 @@ jobs:
           distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/dokka-gh-pages.yml
+++ b/.github/workflows/dokka-gh-pages.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Set up JDK 11
         uses: actions/setup-java@v5
@@ -44,13 +44,13 @@ jobs:
           distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build the distribution with Gradle Wrapper
         run: ./gradlew :dokkaGeneratePublicationHtml
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: build/dokka/html/
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Inlines the `huanshankeji/.github` composite actions (`gradle-test-and-check`, `gradle-dependency-submission`) directly into `.github/workflows/ci.yml`.
- Bumps all GitHub Actions across CI-related workflows to their latest major versions.
- Adopts Gradle **Enhanced Caching** by upgrading to `gradle/actions/setup-gradle@v6` and `gradle/actions/dependency-submission@v6` (Enhanced Caching is the default `cache-provider` in v6).

## Changes

### `.github/workflows/ci.yml`
- Replaced composite action references with inline steps: checkout, JDK 11/17 setup, Gradle setup, `test`, and `check`.
- Dependency submission job now uses `gradle/actions/dependency-submission@v6` directly.

### `.github/workflows/copilot-setup-steps.yml`
- `actions/checkout@v5` → `@v6`
- `gradle/actions/setup-gradle@v4` → `@v6`

### `.github/workflows/dokka-gh-pages.yml`
- `actions/checkout@v4` → `@v6`
- `actions/configure-pages@v5` → `@v6`
- `gradle/actions/setup-gradle@v4` → `@v6`
- `actions/upload-pages-artifact@v3` → `@v5`
- `actions/deploy-pages@v4` → `@v5`

## Action version summary

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4/v5 | **v6** |
| `actions/setup-java` | v5 | v5 (latest) |
| `gradle/actions/setup-gradle` | v4 | **v6** (Enhanced Caching) |
| `gradle/actions/dependency-submission` | v4 (via composite) | **v6** (Enhanced Caching) |
| `actions/configure-pages` | v5 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

## Notes

Enhanced Caching is enabled by default in `gradle/actions` v6 — no explicit `cache-provider` input is required. This uses the proprietary `gradle-actions-caching` provider, which is free for public repositories.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9fd27d6-cf19-480b-917a-8c589d80b011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9fd27d6-cf19-480b-917a-8c589d80b011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

