### PR TITLE
Centralize gradle-common plugin version in a version catalog

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,13 +7,10 @@ repositories {
     gradlePluginPortal()
 }
 
-val gradleCommonPluginsVersion =
-    "0.12.0-dev-commit-de901bb887cefa0f1e0894e8e0471a703e5e5e17"
-
 dependencies {
     implementation(kotlin("gradle-plugin", "2.4.0"))
     implementation("com.huanshankeji:common-gradle-dependencies:0.10.0-20251024")
-    implementation("com.huanshankeji.team:project-gradle-plugins:$gradleCommonPluginsVersion")
-    implementation("com.huanshankeji:kotlin-common-project-gradle-plugins:$gradleCommonPluginsVersion")
+    implementation(libs.huanshankeji.team.project.gradle.plugins)
+    implementation(libs.huanshankeji.kotlin.common.project.gradle.plugins)
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:2.2.0")
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,13 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "buildSrc"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,10 @@
+[versions]
+gradle-common-plugins = "0.12.0-dev-commit-de901bb887cefa0f1e0894e8e0471a703e5e5e17"
+
+[libraries]
+huanshankeji-team-settings-gradle-plugins = { module = "com.huanshankeji.team:settings-gradle-plugins", version.ref = "gradle-common-plugins" }
+huanshankeji-team-project-gradle-plugins = { module = "com.huanshankeji.team:project-gradle-plugins", version.ref = "gradle-common-plugins" }
+huanshankeji-kotlin-common-project-gradle-plugins = { module = "com.huanshankeji:kotlin-common-project-gradle-plugins", version.ref = "gradle-common-plugins" }
+
+[plugins]
+huanshankeji-base-settings-conventions = { id = "com.huanshankeji.base-settings-conventions", version.ref = "gradle-common-plugins" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,16 +30,22 @@ pluginManagement {
 }
 
 buildscript {
+    // Version catalog accessors are unavailable here; read from the TOML directly.
     val gradleCommonPluginsVersion =
-        "0.12.0-dev-commit-de901bb887cefa0f1e0894e8e0471a703e5e5e17"
+        Regex("""(?m)^gradle-common-plugins\s*=\s*"([^"]+)"""")
+            .find(file("gradle/libs.versions.toml").readText())!!
+            .groupValues[1]
     dependencies {
         classpath("com.huanshankeji.team:settings-gradle-plugins:$gradleCommonPluginsVersion")
     }
 }
 
 plugins {
+    // Version catalog accessors are unavailable here; read from the TOML directly.
     val gradleCommonPluginsVersion =
-        "0.12.0-dev-commit-de901bb887cefa0f1e0894e8e0471a703e5e5e17"
+        Regex("""(?m)^gradle-common-plugins\s*=\s*"([^"]+)"""")
+            .find(file("gradle/libs.versions.toml").readText())!!
+            .groupValues[1]
     id("com.huanshankeji.base-settings-conventions") version gradleCommonPluginsVersion
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `gradle/libs.versions.toml` with a single `gradle-common-plugins` version shared by settings and `buildSrc`.
- Read that version from the TOML in the settings `buildscript` / `plugins` blocks (catalog accessors are unavailable there due to the settings-plugin chicken-and-egg).
- Register the catalog in `buildSrc/settings.gradle.kts` and consume it from `buildSrc/build.gradle.kts`.

## Test plan
- [x] `./gradlew help`
- [x] `./gradlew projects`
- [x] Configuration cache reuse on a second `./gradlew help`
- [ ] CI on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2602bc91-33e7-416e-9dd9-6c038b2385ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2602bc91-33e7-416e-9dd9-6c038b2385ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

