### PR TITLE
Fix buildSrc resolution of gradle-common from GitHub Packages

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,13 +4,14 @@ plugins {
 
 repositories {
     gradlePluginPortal()
-    // Bootstrap: same exclusiveContent as settings.gradle.kts pluginManagement.
     exclusiveContent {
         forRepository {
             mavenLocal()
         }
         forRepository {
             maven {
+                // Same bootstrap as settings.gradle.kts pluginManagement — buildSrc resolves
+                // gradle-common plugins as implementation deps, not via the plugins DSL.
                 url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
                 credentials {
                     username = providers.gradleProperty("gpr.user")
@@ -26,12 +27,8 @@ repositories {
     }
 }
 
-// buildSrc does not inherit root gradle.properties as Gradle properties.
 val gradleCommonPluginsVersion =
-    file("../gradle.properties").readLines()
-        .map { it.substringBefore('#').trim() }
-        .first { it.startsWith("gradleCommonPluginsVersion=") }
-        .substringAfter("=")
+    "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
 
 dependencies {
     implementation(kotlin("gradle-plugin", "2.4.0"))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 apply(from = "../gradle/classpath-bootstrap.gradle.kts")
 @Suppress("UNCHECKED_CAST")
-(extra["gradleCommonDevCommitRepos"] as RepositoryHandler.() -> Unit)(repositories)
+(extra["repositories"] as RepositoryHandler.() -> Unit)(repositories)
 
 val gradleCommonPluginsVersion = extra["gradleCommonPluginsVersion"]
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,34 +1,14 @@
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
 plugins {
     `kotlin-dsl`
 }
 
-repositories {
-    gradlePluginPortal()
-    exclusiveContent {
-        forRepository {
-            mavenLocal()
-        }
-        forRepository {
-            maven {
-                // Same bootstrap as settings.gradle.kts pluginManagement — buildSrc resolves
-                // gradle-common plugins as implementation deps, not via the plugins DSL.
-                url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
-                credentials {
-                    username = providers.gradleProperty("gpr.user")
-                        .orElse(providers.gradleProperty("gprUser")).getOrNull()
-                    password = providers.gradleProperty("gpr.key")
-                        .orElse(providers.gradleProperty("gprKey")).getOrNull()
-                }
-            }
-        }
-        filter {
-            includeVersionByRegex("""com\.huanshankeji(\..+)?""", ".*", """.*-dev-commit-[0-9a-f]+.*""")
-        }
-    }
-}
+apply(from = "../gradle/classpath-bootstrap.gradle.kts")
+@Suppress("UNCHECKED_CAST")
+(extra["gradleCommonDevCommitRepos"] as RepositoryHandler.() -> Unit)(repositories)
 
-val gradleCommonPluginsVersion =
-    "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
+val gradleCommonPluginsVersion = extra["gradleCommonPluginsVersion"]
 
 dependencies {
     implementation(kotlin("gradle-plugin", "2.4.0"))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,14 +4,13 @@ plugins {
 
 repositories {
     gradlePluginPortal()
+    // Bootstrap: same exclusiveContent as settings.gradle.kts pluginManagement.
     exclusiveContent {
         forRepository {
             mavenLocal()
         }
         forRepository {
             maven {
-                // Same bootstrap as settings.gradle.kts pluginManagement — buildSrc resolves
-                // gradle-common plugins as implementation deps, not via the plugins DSL.
                 url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
                 credentials {
                     username = providers.gradleProperty("gpr.user")
@@ -27,8 +26,12 @@ repositories {
     }
 }
 
+// buildSrc does not inherit root gradle.properties as Gradle properties.
 val gradleCommonPluginsVersion =
-    "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
+    file("../gradle.properties").readLines()
+        .map { it.substringBefore('#').trim() }
+        .first { it.startsWith("gradleCommonPluginsVersion=") }
+        .substringAfter("=")
 
 dependencies {
     implementation(kotlin("gradle-plugin", "2.4.0"))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,8 +3,28 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     gradlePluginPortal()
+    exclusiveContent {
+        forRepository {
+            mavenLocal()
+        }
+        forRepository {
+            maven {
+                // Same bootstrap as settings.gradle.kts pluginManagement — buildSrc resolves
+                // gradle-common plugins as implementation deps, not via the plugins DSL.
+                url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
+                credentials {
+                    username = providers.gradleProperty("gpr.user")
+                        .orElse(providers.gradleProperty("gprUser")).getOrNull()
+                    password = providers.gradleProperty("gpr.key")
+                        .orElse(providers.gradleProperty("gprKey")).getOrNull()
+                }
+            }
+        }
+        filter {
+            includeVersionByRegex("""com\.huanshankeji(\..+)?""", ".*", """.*-dev-commit-[0-9a-f]+.*""")
+        }
+    }
 }
 
 val gradleCommonPluginsVersion =

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,3 @@ org.gradle.configuration-cache=true
 # needed for the GitHub Actions CI
 org.gradle.jvmargs=-Xmx4G
 kotlin.native.enableKlibsCrossCompilation=true
-
-# Dev-commit gradle-common plugins (settings + buildSrc). Bump when upgrading.
-gradleCommonPluginsVersion=0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ org.gradle.configuration-cache=true
 # needed for the GitHub Actions CI
 org.gradle.jvmargs=-Xmx4G
 kotlin.native.enableKlibsCrossCompilation=true
+
+# Dev-commit gradle-common plugins (settings + buildSrc). Bump when upgrading.
+gradleCommonPluginsVersion=0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50

--- a/gradle/classpath-bootstrap.gradle.kts
+++ b/gradle/classpath-bootstrap.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Shared early classpath bootstrap for settings (pluginManagement) and buildSrc:
+ * versions and repositories needed before project conventions are on the classpath.
+ *
+ * Currently wires GitHub Packages / mavenLocal for gradle-common *-dev-commit-* artifacts.
+ * Copied and adapted from (gradle-common APIs are not on the classpath yet):
+ * https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
+ */
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+extra["gradleCommonPluginsVersion"] = "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
+
+extra["gradleCommonDevCommitRepos"] = fun RepositoryHandler.() {
+    gradlePluginPortal()
+    exclusiveContent {
+        forRepository {
+            mavenLocal()
+        }
+        forRepository {
+            maven {
+                url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
+                credentials {
+                    username = providers.gradleProperty("gpr.user")
+                        .orElse(providers.gradleProperty("gprUser")).getOrNull()
+                    password = providers.gradleProperty("gpr.key")
+                        .orElse(providers.gradleProperty("gprKey")).getOrNull()
+                }
+            }
+        }
+        filter {
+            includeVersionByRegex("""com\.huanshankeji(\..+)?""", ".*", """.*-dev-commit-[0-9a-f]+.*""")
+        }
+    }
+}

--- a/gradle/classpath-bootstrap.gradle.kts
+++ b/gradle/classpath-bootstrap.gradle.kts
@@ -3,18 +3,22 @@
  * versions and repositories needed before project conventions are on the classpath.
  */
 
-// Currently wires GitHub Packages / mavenLocal for gradle-common *-dev-commit-* artifacts.
+// Currently wires GitHub Packages / mavenLocal for gradle-common *-dev-commit-* artifacts. gradle-common APIs are not on the classpath yet.
 extra["repositories"] = fun RepositoryHandler.() {
     gradlePluginPortal()
+    /*
+    Adapted (simplified) from:
+    https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/gitversioning/opensourceconvention/Repository.kt
+    */
     exclusiveContent {
         forRepository {
             mavenLocal()
         }
         forRepository {
             /*
-             Copied and adapted from (gradle-common APIs are not on the classpath yet):
-             https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
-             */
+            Adapted from:
+            https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
+            */
             maven {
                 url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
                 credentials {

--- a/gradle/classpath-bootstrap.gradle.kts
+++ b/gradle/classpath-bootstrap.gradle.kts
@@ -1,30 +1,27 @@
 /*
  * Shared early classpath bootstrap for settings (pluginManagement) and buildSrc:
  * versions and repositories needed before project conventions are on the classpath.
- *
- * Currently wires GitHub Packages / mavenLocal for gradle-common *-dev-commit-* artifacts.
- * Copied and adapted from (gradle-common APIs are not on the classpath yet):
- * https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
  */
 
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-
-extra["gradleCommonPluginsVersion"] = "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
-
-extra["gradleCommonDevCommitRepos"] = fun RepositoryHandler.() {
+// Currently wires GitHub Packages / mavenLocal for gradle-common *-dev-commit-* artifacts.
+extra["repositories"] = fun RepositoryHandler.() {
     gradlePluginPortal()
     exclusiveContent {
         forRepository {
             mavenLocal()
         }
         forRepository {
+            /*
+             Copied and adapted from (gradle-common APIs are not on the classpath yet):
+             https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
+             */
             maven {
                 url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
                 credentials {
-                    username = providers.gradleProperty("gpr.user")
-                        .orElse(providers.gradleProperty("gprUser")).getOrNull()
-                    password = providers.gradleProperty("gpr.key")
-                        .orElse(providers.gradleProperty("gprKey")).getOrNull()
+                    with(providers) {
+                        username = gradleProperty("gpr.user").orElse(gradleProperty("gprUser")).getOrNull()
+                        password = gradleProperty("gpr.key").orElse(gradleProperty("gprKey")).getOrNull()
+                    }
                 }
             }
         }
@@ -33,3 +30,6 @@ extra["gradleCommonDevCommitRepos"] = fun RepositoryHandler.() {
         }
     }
 }
+
+extra["gradleCommonPluginsVersion"] = "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
+

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1790,7 +1790,16 @@ streamroller@^3.1.2:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1808,7 +1817,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2045,7 +2061,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,45 +1,20 @@
 import com.huanshankeji.team.artifacts.mavenCentralExcludingHuanshankeji
 
 pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        exclusiveContent {
-            forRepository {
-                mavenLocal()
-            }
-            forRepository {
-                maven {
-                    // Resolves the gradle-common settings plugin when it is not in mavenLocal().
-                    // Mirrors gradle-common credential resolution; its APIs cannot be called from settings.gradle.kts:
-                    // https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
-                    url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
-                    credentials {
-                        with(providers) {
-                            username = gradleProperty("gpr.user").orElse(gradleProperty("gprUser")).getOrNull()
-                            password = gradleProperty("gpr.key").orElse(gradleProperty("gprKey")).getOrNull()
-                        }
-                    }
-                }
-            }
-            filter {
-                includeVersionByRegex("""com\.huanshankeji(\..+)?""", ".*", """.*-dev-commit-[0-9a-f]+.*""")
-            }
-        }
-    }
+    // Must apply inside this block: Kotlin DSL runs pluginManagement before top-level statements.
+    apply(from = "gradle/classpath-bootstrap.gradle.kts")
+    @Suppress("UNCHECKED_CAST")
+    (extra["gradleCommonDevCommitRepos"] as RepositoryHandler.() -> Unit)(repositories)
 }
 
 buildscript {
-    val gradleCommonPluginsVersion =
-        "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
     dependencies {
-        classpath("com.huanshankeji.team:settings-gradle-plugins:$gradleCommonPluginsVersion")
+        classpath("com.huanshankeji.team:settings-gradle-plugins:${settings.extra["gradleCommonPluginsVersion"]}")
     }
 }
 
 plugins {
-    val gradleCommonPluginsVersion =
-        "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
-    id("com.huanshankeji.base-settings-conventions") version gradleCommonPluginsVersion
+    id("com.huanshankeji.base-settings-conventions") version (extra["gradleCommonPluginsVersion"] as String)
 }
 
 @Suppress("UnstableApiUsage")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,13 +3,15 @@ import com.huanshankeji.team.artifacts.mavenCentralExcludingHuanshankeji
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        // Bootstrap: same exclusiveContent as buildSrc/build.gradle.kts (pluginManagement is isolated).
         exclusiveContent {
             forRepository {
                 mavenLocal()
             }
             forRepository {
                 maven {
+                    // Resolves the gradle-common settings plugin when it is not in mavenLocal().
+                    // Mirrors gradle-common credential resolution; its APIs cannot be called from settings.gradle.kts:
+                    // https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
                     url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
                     credentials {
                         with(providers) {
@@ -28,14 +30,16 @@ pluginManagement {
 
 buildscript {
     val gradleCommonPluginsVersion =
-        providers.gradleProperty("gradleCommonPluginsVersion").get()
+        "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
     dependencies {
         classpath("com.huanshankeji.team:settings-gradle-plugins:$gradleCommonPluginsVersion")
     }
 }
 
 plugins {
-    id("com.huanshankeji.base-settings-conventions") version providers.gradleProperty("gradleCommonPluginsVersion").get()
+    val gradleCommonPluginsVersion =
+        "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
+    id("com.huanshankeji.base-settings-conventions") version gradleCommonPluginsVersion
 }
 
 @Suppress("UnstableApiUsage")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
     // Must apply inside this block: Kotlin DSL runs pluginManagement before top-level statements.
     apply(from = "gradle/classpath-bootstrap.gradle.kts")
     @Suppress("UNCHECKED_CAST")
-    (extra["gradleCommonDevCommitRepos"] as RepositoryHandler.() -> Unit)(repositories)
+    (extra["repositories"] as RepositoryHandler.() -> Unit)(repositories)
 }
 
 buildscript {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,15 +3,13 @@ import com.huanshankeji.team.artifacts.mavenCentralExcludingHuanshankeji
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        // Bootstrap: same exclusiveContent as buildSrc/build.gradle.kts (pluginManagement is isolated).
         exclusiveContent {
             forRepository {
                 mavenLocal()
             }
             forRepository {
                 maven {
-                    // Resolves the gradle-common settings plugin when it is not in mavenLocal().
-                    // Mirrors gradle-common credential resolution; its APIs cannot be called from settings.gradle.kts:
-                    // https://github.com/huanshankeji/gradle-common/blob/main/kotlin-common/gradle-library/src/main/kotlin/com/huanshankeji/github/packages/maven/GithubPackagesMavenRegistry.kt
                     url = uri("https://maven.pkg.github.com/huanshankeji/gradle-common")
                     credentials {
                         with(providers) {
@@ -30,16 +28,14 @@ pluginManagement {
 
 buildscript {
     val gradleCommonPluginsVersion =
-        "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
+        providers.gradleProperty("gradleCommonPluginsVersion").get()
     dependencies {
         classpath("com.huanshankeji.team:settings-gradle-plugins:$gradleCommonPluginsVersion")
     }
 }
 
 plugins {
-    val gradleCommonPluginsVersion =
-        "0.12.0-dev-commit-656d3d5f54d76c571b79f96ecc236cb54b013f50"
-    id("com.huanshankeji.base-settings-conventions") version gradleCommonPluginsVersion
+    id("com.huanshankeji.base-settings-conventions") version providers.gradleProperty("gradleCommonPluginsVersion").get()
 }
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
## Summary
- Fix CI resolution of gradle-common plugins in `buildSrc` (`project-gradle-plugins` / `kotlin-common-project-gradle-plugins` are `implementation` deps, so `pluginManagement` alone is not enough without `mavenLocal`)
- Share the chicken/egg bootstrap in `gradle/classpath-bootstrap.gradle.kts`: gradle-common plugin version + `exclusiveContent` (mavenLocal + GitHub Packages for `*-dev-commit-*`), applied from both `settings` `pluginManagement` and `buildSrc`
- Refresh `kotlin-js-store/yarn.lock` after dependency resolution changes

## Test plan
- [x] CI `check` resolves gradle-common plugins from GitHub Packages
- [x] Publish workflow gets past `:buildSrc:generateExternalPluginSpecBuilders`
- [x] Local `./gradlew check` still works with mavenLocal and/or `gprUser`/`gprKey`