### PR TITLE
Inline version into common-conventions and remove version.gradle.kts

### DIFF
--- a/buildSrc/src/main/kotlin/common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-conventions.gradle.kts
@@ -1,12 +1,14 @@
 import com.huanshankeji.team.ShreckYe
 import com.huanshankeji.team.setUpPomForTeamDefaultOpenSource
+import com.huanshankeji.gitversioning.devCommitOrReleaseVersionProvider
 
 plugins {
     id("com.huanshankeji.team.with-group")
     id("com.huanshankeji.team.gitversioning.opensourceconvention.githubpackages.publish")
-    id("version")
     id("dokka-convention")
 }
+
+version = providers.devCommitOrReleaseVersionProvider(projectBaseVersion, isRelease).get()
 
 gitVersioningOpenSourceConventionGithubPackagesPublish {
     signAllPublicationsIfRelease(isRelease)

--- a/buildSrc/src/main/kotlin/version.gradle.kts
+++ b/buildSrc/src/main/kotlin/version.gradle.kts
@@ -1,5 +1,0 @@
-import com.huanshankeji.gitversioning.devCommitOrReleaseVersionProvider
-
-// extracted into a separate script so the version can be set before `dokka-convention`
-
-version = providers.devCommitOrReleaseVersionProvider(projectBaseVersion, isRelease).get()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Move `devCommitOrReleaseVersionProvider(...)` into `common-conventions.gradle.kts` and delete the separate `version` precompiled script plugin.
- `version.gradle.kts` existed so version was set before `dokka-convention` applied. With the current `github-dokka-convention` / `conventionalGitRef()` Provider-based APIs, that ordering is no longer required.

## Verification

Confirmed after the change:

- `./gradlew :kotlin-common-core:properties` → `version: 0.8.0-dev-commit-<HEAD>`
- `./gradlew :dokkaGeneratePublicationHtml` → **BUILD SUCCESSFUL**
- Generated source links use the HEAD commit hash via `conventionalGitRef()`, e.g. `.../blob/59659c29852b94a36810346c6fe13fafccdb1640/...` (not `unspecified` / wrong tag)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cc4edf3-0fca-4784-9eab-3f81a46d6b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cc4edf3-0fca-4784-9eab-3f81a46d6b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

